### PR TITLE
[Fix] 型による計算処理の再編成

### DIFF
--- a/chapter01/createStatementData.ts
+++ b/chapter01/createStatementData.ts
@@ -53,13 +53,8 @@ class PerformanceCalculator {
     throw new Error('サブクラスの責務');
   }
 
-  get volumeCredits() {
-    let result = 0;
-    result += Math.max(this.performance.audience - 30, 0);
-    // 喜劇のときは10人につき、さらにポイントを加算
-    if ('comedy' === this.play.type)
-      result += Math.floor(this.performance.audience / 5);
-    return result;
+  get volumeCredits(): number {
+    return Math.max(this.performance.audience - 30, 0);
   }
 }
 
@@ -81,5 +76,9 @@ class ComedyCalculator extends PerformanceCalculator {
     }
     result += 300 * this.performance.audience;
     return result;
+  }
+
+  get volumeCredits(): number {
+    return super.volumeCredits + Math.floor(this.performance.audience / 5);
   }
 }

--- a/chapter01/createStatementData.ts
+++ b/chapter01/createStatementData.ts
@@ -17,7 +17,12 @@ export function createStatementData(invoice, plays) {
   }
 
   function createPerformanceCalculator(aPerformance, aPlay) {
-    return new PerformanceCalculator(aPerformance, aPlay);
+    switch(aPlay.type) {
+      case 'tragedy': return new TragedyCalculator(aPerformance, aPlay);
+      case 'comedy': return new ComedyCalculator(aPerformance, aPlay);
+      default:
+        throw new Error(`未知の演劇の種類: ${aPlay.type}`);
+    }
   }
 
   function playFor(aPerformance) {
@@ -74,4 +79,10 @@ class PerformanceCalculator {
       result += Math.floor(this.performance.audience / 5);
     return result;
   }
+}
+
+class TragedyCalculator extends PerformanceCalculator {
+}
+
+class ComedyCalculator extends PerformanceCalculator {
 }

--- a/chapter01/createStatementData.ts
+++ b/chapter01/createStatementData.ts
@@ -12,16 +12,12 @@ export function createStatementData(invoice, plays) {
     const result: any = { ...aPerformance };
     result.play = calculator.play;
     result.amount = calculator.amount;
-    result.volumeCredits = volumeCreditsFor(result);
+    result.volumeCredits = calculator.volumeCredits;
     return result;
   }
 
   function playFor(aPerformance) {
     return plays[aPerformance.playID];
-  }
-
-  function volumeCreditsFor(aPerformance) {
-    return new PerformanceCalculator(aPerformance, playFor(aPerformance)).volumeCredits;
   }
 
   function totalAmount(data) {

--- a/chapter01/createStatementData.ts
+++ b/chapter01/createStatementData.ts
@@ -8,6 +8,7 @@ export function createStatementData(invoice, plays) {
   return result;
 
   function enrichPerformance(aPerformance) {
+    const calculator = new PerformanceCalculator(aPerformance);
     const result: any = { ...aPerformance };
     result.play = playFor(aPerformance);
     result.amount = amountFor(result);
@@ -58,5 +59,13 @@ export function createStatementData(invoice, plays) {
   function totalVolumeCredits(data) {
     return data.performances
       .reduce((total, p) => total + p.volumeCredits, 0);
+  }
+}
+
+class PerformanceCalculator {
+  performance: any;
+
+  constructor(aPerformance) {
+    this.performance = aPerformance;
   }
 }

--- a/chapter01/createStatementData.ts
+++ b/chapter01/createStatementData.ts
@@ -21,12 +21,7 @@ export function createStatementData(invoice, plays) {
   }
 
   function volumeCreditsFor(aPerformance) {
-    let result = 0;
-    result += Math.max(aPerformance.audience - 30, 0);
-    // 喜劇のときは10人につき、さらにポイントを加算
-    if ('comedy' === aPerformance.play.type)
-      result += Math.floor(aPerformance.audience / 5);
-    return result;
+    return new PerformanceCalculator(aPerformance, playFor(aPerformance)).volumeCredits;
   }
 
   function totalAmount(data) {
@@ -68,6 +63,15 @@ class PerformanceCalculator {
       default:
         throw new Error(`unknown type: ${this.play.type}`);
     }
+    return result;
+  }
+
+  get volumeCredits() {
+    let result = 0;
+    result += Math.max(this.performance.audience - 30, 0);
+    // 喜劇のときは10人につき、さらにポイントを加算
+    if ('comedy' === this.play.type)
+      result += Math.floor(this.performance.audience / 5);
     return result;
   }
 }

--- a/chapter01/createStatementData.ts
+++ b/chapter01/createStatementData.ts
@@ -8,9 +8,9 @@ export function createStatementData(invoice, plays) {
   return result;
 
   function enrichPerformance(aPerformance) {
-    const calculator = new PerformanceCalculator(aPerformance);
+    const calculator = new PerformanceCalculator(aPerformance, playFor(aPerformance));
     const result: any = { ...aPerformance };
-    result.play = playFor(aPerformance);
+    result.play = calculator.play;
     result.amount = amountFor(result);
     result.volumeCredits = volumeCreditsFor(result);
     return result;
@@ -64,8 +64,10 @@ export function createStatementData(invoice, plays) {
 
 class PerformanceCalculator {
   performance: any;
+  play: any;
 
-  constructor(aPerformance) {
+  constructor(aPerformance, aPlay) {
     this.performance = aPerformance;
+    this.play = aPlay;
   }
 }

--- a/chapter01/createStatementData.ts
+++ b/chapter01/createStatementData.ts
@@ -49,17 +49,8 @@ class PerformanceCalculator {
     this.play = aPlay;
   }
 
-  get amount() {
-    let result = 0;
-    switch (this.play.type) {
-      case 'tragedy':
-        throw '想定外の呼び出し';
-      case 'comedy':
-        throw '想定外の呼び出し';
-      default:
-        throw new Error(`unknown type: ${this.play.type}`);
-    }
-    return result;
+  get amount(): Number {
+    throw new Error('サブクラスの責務');
   }
 
   get volumeCredits() {
@@ -73,7 +64,7 @@ class PerformanceCalculator {
 }
 
 class TragedyCalculator extends PerformanceCalculator {
-  get amount() {
+  get amount(): Number {
     let result = 40000;
     if (this.performance.audience > 30) {
       result += 1000 * (this.performance.audience - 30);
@@ -83,7 +74,7 @@ class TragedyCalculator extends PerformanceCalculator {
 }
 
 class ComedyCalculator extends PerformanceCalculator {
-  get amount() {
+  get amount(): Number {
     let result = 30000;
     if (this.performance.audience > 20) {
       result += 10000 + 500 * (this.performance.audience - 20);

--- a/chapter01/createStatementData.ts
+++ b/chapter01/createStatementData.ts
@@ -53,11 +53,7 @@ class PerformanceCalculator {
     let result = 0;
     switch (this.play.type) {
       case 'tragedy':
-        result = 40000;
-        if (this.performance.audience > 30) {
-          result += 1000 * (this.performance.audience - 30);
-        }
-        break;
+        throw '想定外の呼び出し';
       case 'comedy':
         result = 30000;
         if (this.performance.audience > 20) {
@@ -82,6 +78,13 @@ class PerformanceCalculator {
 }
 
 class TragedyCalculator extends PerformanceCalculator {
+  get amount() {
+    let result = 40000;
+    if (this.performance.audience > 30) {
+      result += 1000 * (this.performance.audience - 30);
+    }
+    return result;
+  }
 }
 
 class ComedyCalculator extends PerformanceCalculator {

--- a/chapter01/createStatementData.ts
+++ b/chapter01/createStatementData.ts
@@ -55,12 +55,7 @@ class PerformanceCalculator {
       case 'tragedy':
         throw '想定外の呼び出し';
       case 'comedy':
-        result = 30000;
-        if (this.performance.audience > 20) {
-          result += 10000 + 500 * (this.performance.audience - 20);
-        }
-        result += 300 * this.performance.audience;
-        break;
+        throw '想定外の呼び出し';
       default:
         throw new Error(`unknown type: ${this.play.type}`);
     }
@@ -88,4 +83,12 @@ class TragedyCalculator extends PerformanceCalculator {
 }
 
 class ComedyCalculator extends PerformanceCalculator {
+  get amount() {
+    let result = 30000;
+    if (this.performance.audience > 20) {
+      result += 10000 + 500 * (this.performance.audience - 20);
+    }
+    result += 300 * this.performance.audience;
+    return result;
+  }
 }

--- a/chapter01/createStatementData.ts
+++ b/chapter01/createStatementData.ts
@@ -8,12 +8,16 @@ export function createStatementData(invoice, plays) {
   return result;
 
   function enrichPerformance(aPerformance) {
-    const calculator = new PerformanceCalculator(aPerformance, playFor(aPerformance));
+    const calculator = createPerformanceCalculator(aPerformance, playFor(aPerformance));
     const result: any = { ...aPerformance };
     result.play = calculator.play;
     result.amount = calculator.amount;
     result.volumeCredits = calculator.volumeCredits;
     return result;
+  }
+
+  function createPerformanceCalculator(aPerformance, aPlay) {
+    return new PerformanceCalculator(aPerformance, aPlay);
   }
 
   function playFor(aPerformance) {

--- a/chapter01/createStatementData.ts
+++ b/chapter01/createStatementData.ts
@@ -21,25 +21,7 @@ export function createStatementData(invoice, plays) {
   }
 
   function amountFor(aPerformance) {
-    let result = 0;
-    switch (aPerformance.play.type) {
-      case 'tragedy':
-        result = 40000;
-        if (aPerformance.audience > 30) {
-          result += 1000 * (aPerformance.audience - 30);
-        }
-        break;
-      case 'comedy':
-        result = 30000;
-        if (aPerformance.audience > 20) {
-          result += 10000 + 500 * (aPerformance.audience - 20);
-        }
-        result += 300 * aPerformance.audience;
-        break;
-      default:
-        throw new Error(`unknown type: ${aPerformance.play.type}`);
-    }
-    return result;
+    return new PerformanceCalculator(aPerformance, playFor(aPerformance)).amount;
   }
 
   function volumeCreditsFor(aPerformance) {
@@ -69,5 +51,27 @@ class PerformanceCalculator {
   constructor(aPerformance, aPlay) {
     this.performance = aPerformance;
     this.play = aPlay;
+  }
+
+  get amount() {
+    let result = 0;
+    switch (this.play.type) {
+      case 'tragedy':
+        result = 40000;
+        if (this.performance.audience > 30) {
+          result += 1000 * (this.performance.audience - 30);
+        }
+        break;
+      case 'comedy':
+        result = 30000;
+        if (this.performance.audience > 20) {
+          result += 10000 + 500 * (this.performance.audience - 20);
+        }
+        result += 300 * this.performance.audience;
+        break;
+      default:
+        throw new Error(`unknown type: ${this.play.type}`);
+    }
+    return result;
   }
 }

--- a/chapter01/createStatementData.ts
+++ b/chapter01/createStatementData.ts
@@ -11,17 +11,13 @@ export function createStatementData(invoice, plays) {
     const calculator = new PerformanceCalculator(aPerformance, playFor(aPerformance));
     const result: any = { ...aPerformance };
     result.play = calculator.play;
-    result.amount = amountFor(result);
+    result.amount = calculator.amount;
     result.volumeCredits = volumeCreditsFor(result);
     return result;
   }
 
   function playFor(aPerformance) {
     return plays[aPerformance.playID];
-  }
-
-  function amountFor(aPerformance) {
-    return new PerformanceCalculator(aPerformance, playFor(aPerformance)).amount;
   }
 
   function volumeCreditsFor(aPerformance) {

--- a/chapter01/tsconfig.json
+++ b/chapter01/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "moduleResolution": "node",
     "resolveJsonModule": true,
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "target": "ES2015"
   }
 }


### PR DESCRIPTION
`PerformanceCalculator` クラスを作成し、請求額計算、ボリューム特典ポイント計算の処理を「ポリモーフィズムによる条件記述の置き換え」により、継承先クラスに任せるように変更しました。